### PR TITLE
build: soong: use jemalloc by default and allow opt-in to scudo (2/3)

### DIFF
--- a/android/config.go
+++ b/android/config.go
@@ -965,7 +965,7 @@ func (c *config) EnableCFI() bool {
 }
 
 func (c *config) DisableScudo() bool {
-	return Bool(c.productVariables.DisableScudo)
+	return !Bool(c.productVariables.Malloc_use_scudo)
 }
 
 func (c *config) Android64() bool {

--- a/android/variable.go
+++ b/android/variable.go
@@ -64,13 +64,17 @@ type variableProperties struct {
 			Enabled *bool `android:"arch_variant"`
 		} `android:"arch_variant"`
 
-		Malloc_not_svelte struct {
+		Malloc_use_scudo struct {
 			Cflags              []string `android:"arch_variant"`
 			Shared_libs         []string `android:"arch_variant"`
 			Whole_static_libs   []string `android:"arch_variant"`
 			Exclude_static_libs []string `android:"arch_variant"`
 			Srcs                []string `android:"arch_variant"`
 			Header_libs         []string `android:"arch_variant"`
+		} `android:"arch_variant"`
+
+		Malloc_not_svelte struct {
+			Cflags              []string `android:"arch_variant"`
 		} `android:"arch_variant"`
 
 		Malloc_zero_contents struct {
@@ -259,6 +263,7 @@ type productVariables struct {
 	Unbundled_build_image        *bool    `json:",omitempty"`
 	Always_use_prebuilt_sdks     *bool    `json:",omitempty"`
 	Skip_boot_jars_check         *bool    `json:",omitempty"`
+	Malloc_use_scudo 	     *bool    `json:",omitempty"`
 	Malloc_not_svelte            *bool    `json:",omitempty"`
 	Malloc_zero_contents         *bool    `json:",omitempty"`
 	Malloc_pattern_fill_contents *bool    `json:",omitempty"`
@@ -291,8 +296,6 @@ type productVariables struct {
 	EnableCFI       *bool    `json:",omitempty"`
 	CFIExcludePaths []string `json:",omitempty"`
 	CFIIncludePaths []string `json:",omitempty"`
-
-	DisableScudo *bool `json:",omitempty"`
 
 	MemtagHeapExcludePaths      []string `json:",omitempty"`
 	MemtagHeapAsyncIncludePaths []string `json:",omitempty"`
@@ -490,7 +493,8 @@ func (v *productVariables) SetDefaultConfig() {
 		AAPTPreferredConfig: stringPtr("xhdpi"),
 		AAPTCharacteristics: stringPtr("nosdcard"),
 		AAPTPrebuiltDPI:     []string{"xhdpi", "xxhdpi"},
-
+		
+		Malloc_use_scudo:             boolPtr(false),
 		Malloc_not_svelte:            boolPtr(true),
 		Malloc_zero_contents:         boolPtr(true),
 		Malloc_pattern_fill_contents: boolPtr(false),

--- a/bp2build/cc_library_conversion_test.go
+++ b/bp2build/cc_library_conversion_test.go
@@ -1100,11 +1100,11 @@ cc_library {
     srcs: ["common.c"],
     whole_static_libs: [
         "arm_whole_static_lib_excludes",
-        "malloc_not_svelte_whole_static_lib_excludes"
+        "malloc_use_scudo_whole_static_lib_excludes"
     ],
     static_libs: [
         "arm_static_lib_excludes",
-        "malloc_not_svelte_static_lib_excludes"
+        "malloc_use_scudo_static_lib_excludes"
     ],
     shared_libs: [
         "arm_shared_lib_excludes",
@@ -1121,12 +1121,12 @@ cc_library {
         },
     },
     product_variables: {
-        malloc_not_svelte: {
-            shared_libs: ["malloc_not_svelte_shared_lib"],
-            whole_static_libs: ["malloc_not_svelte_whole_static_lib"],
+        malloc_use_scudo: {
+            shared_libs: ["malloc_use_scudo_shared_lib"],
+            whole_static_libs: ["malloc_use_scudo_whole_static_lib"],
             exclude_static_libs: [
-                "malloc_not_svelte_static_lib_excludes",
-                "malloc_not_svelte_whole_static_lib_excludes",
+                "malloc_use_scudo_static_lib_excludes",
+                "malloc_use_scudo_whole_static_lib_excludes",
             ],
         },
     },
@@ -1139,12 +1139,12 @@ cc_library {
 }
 
 cc_library {
-    name: "malloc_not_svelte_whole_static_lib",
+    name: "malloc_use_scudo_whole_static_lib",
     bazel_module: { bp2build_available: false },
 }
 
 cc_library {
-    name: "malloc_not_svelte_whole_static_lib_excludes",
+    name: "malloc_use_scudo_whole_static_lib_excludes",
     bazel_module: { bp2build_available: false },
 }
 
@@ -1154,7 +1154,7 @@ cc_library {
 }
 
 cc_library {
-    name: "malloc_not_svelte_static_lib_excludes",
+    name: "malloc_use_scudo_static_lib_excludes",
     bazel_module: { bp2build_available: false },
 }
 
@@ -1164,7 +1164,7 @@ cc_library {
 }
 
 cc_library {
-    name: "malloc_not_svelte_shared_lib",
+    name: "malloc_use_scudo_shared_lib",
     bazel_module: { bp2build_available: false },
 }
 `,
@@ -1173,14 +1173,14 @@ cc_library {
         "//build/bazel/platforms/arch:arm": [],
         "//conditions:default": [":arm_static_lib_excludes_bp2build_cc_library_static"],
     }) + select({
-        "//build/bazel/product_variables:malloc_not_svelte": [],
-        "//conditions:default": [":malloc_not_svelte_static_lib_excludes_bp2build_cc_library_static"],
+        "//build/bazel/product_variables:malloc_use_scudo": [],
+        "//conditions:default": [":malloc_use_scudo_static_lib_excludes_bp2build_cc_library_static"],
     })`,
 			"implementation_dynamic_deps": `select({
         "//build/bazel/platforms/arch:arm": [],
         "//conditions:default": [":arm_shared_lib_excludes"],
     }) + select({
-        "//build/bazel/product_variables:malloc_not_svelte": [":malloc_not_svelte_shared_lib"],
+        "//build/bazel/product_variables:malloc_use_scudo": [":malloc_use_scudo_shared_lib"],
         "//conditions:default": [],
     })`,
 			"srcs_c": `["common.c"]`,
@@ -1188,8 +1188,8 @@ cc_library {
         "//build/bazel/platforms/arch:arm": [],
         "//conditions:default": [":arm_whole_static_lib_excludes_bp2build_cc_library_static"],
     }) + select({
-        "//build/bazel/product_variables:malloc_not_svelte": [":malloc_not_svelte_whole_static_lib_bp2build_cc_library_static"],
-        "//conditions:default": [":malloc_not_svelte_whole_static_lib_excludes_bp2build_cc_library_static"],
+        "//build/bazel/product_variables:malloc_use_scudo": [":malloc_use_scudo_whole_static_lib_bp2build_cc_library_static"],
+        "//conditions:default": [":malloc_use_scudo_whole_static_lib_excludes_bp2build_cc_library_static"],
     })`,
 		}),
 	},


### PR DESCRIPTION
Also, clean up broken DisableScudo/PRODUCT_DISABLE_SCUDO.

After these changes, malloc_not_svelte is only used to override cflags in external/jemalloc_new. Change accordingly.

Detailed reason for switching to jemalloc by default is written in the bionic commit.

Change-Id: Id5afcf064a5db6011676dc7141c71fd5bb0007cb