### PR TITLE
build: soong: use jemalloc by default and allow opt-in to scudo (2/3)

### DIFF
--- a/android/config.go
+++ b/android/config.go
@@ -1091,7 +1091,7 @@ func (c *config) EnableCFI() bool {
 }
 
 func (c *config) DisableScudo() bool {
-	return Bool(c.productVariables.DisableScudo)
+	return !Bool(c.productVariables.Malloc_use_scudo)
 }
 
 func (c *config) Android64() bool {

--- a/android/variable.go
+++ b/android/variable.go
@@ -70,7 +70,7 @@ type variableProperties struct {
 			Enabled *bool `android:"arch_variant"`
 		} `android:"arch_variant"`
 
-		Malloc_not_svelte struct {
+		Malloc_use_scudo struct {
 			Cflags              []string `android:"arch_variant"`
 			Shared_libs         []string `android:"arch_variant"`
 			Whole_static_libs   []string `android:"arch_variant"`
@@ -85,6 +85,10 @@ type variableProperties struct {
 			Whole_static_libs   []string `android:"arch_variant"`
 			Exclude_static_libs []string `android:"arch_variant"`
 		} `android:"arch_variant"`
+
+                Malloc_not_svelte struct {
+                        Cflags              []string `android:"arch_variant"`
+                } `android:"arch_variant"`
 
 		Malloc_zero_contents struct {
 			Cflags []string `android:"arch_variant"`
@@ -276,6 +280,7 @@ type productVariables struct {
 	Unbundled_build_image        *bool    `json:",omitempty"`
 	Always_use_prebuilt_sdks     *bool    `json:",omitempty"`
 	Skip_boot_jars_check         *bool    `json:",omitempty"`
+	Malloc_use_scudo 	     *bool    `json:",omitempty"`
 	Malloc_not_svelte            *bool    `json:",omitempty"`
 	Malloc_not_svelte_libc32     *bool    `json:",omitempty"`
 	Malloc_zero_contents         *bool    `json:",omitempty"`
@@ -309,8 +314,6 @@ type productVariables struct {
 	EnableCFI       *bool    `json:",omitempty"`
 	CFIExcludePaths []string `json:",omitempty"`
 	CFIIncludePaths []string `json:",omitempty"`
-
-	DisableScudo *bool `json:",omitempty"`
 
 	MemtagHeapExcludePaths      []string `json:",omitempty"`
 	MemtagHeapAsyncIncludePaths []string `json:",omitempty"`
@@ -530,6 +533,7 @@ func (v *productVariables) SetDefaultConfig() {
 		AAPTCharacteristics: stringPtr("nosdcard"),
 		AAPTPrebuiltDPI:     []string{"xhdpi", "xxhdpi"},
 
+		Malloc_use_scudo:             boolPtr(false),
 		Malloc_not_svelte:            boolPtr(true),
 		Malloc_not_svelte_libc32:     boolPtr(true),
 		Malloc_zero_contents:         boolPtr(true),

--- a/bp2build/cc_library_conversion_test.go
+++ b/bp2build/cc_library_conversion_test.go
@@ -1176,11 +1176,11 @@ cc_library {
     srcs: ["common.c"],
     whole_static_libs: [
         "arm_whole_static_lib_excludes",
-        "malloc_not_svelte_whole_static_lib_excludes"
+        "malloc_use_scudo_whole_static_lib_excludes"
     ],
     static_libs: [
         "arm_static_lib_excludes",
-        "malloc_not_svelte_static_lib_excludes"
+        "malloc_use_scudo_static_lib_excludes"
     ],
     shared_libs: [
         "arm_shared_lib_excludes",
@@ -1197,12 +1197,12 @@ cc_library {
         },
     },
     product_variables: {
-        malloc_not_svelte: {
-            shared_libs: ["malloc_not_svelte_shared_lib"],
-            whole_static_libs: ["malloc_not_svelte_whole_static_lib"],
+        malloc_use_scudo: {
+            shared_libs: ["malloc_use_scudo_shared_lib"],
+            whole_static_libs: ["malloc_use_scudo_whole_static_lib"],
             exclude_static_libs: [
-                "malloc_not_svelte_static_lib_excludes",
-                "malloc_not_svelte_whole_static_lib_excludes",
+                "malloc_use_scudo_static_lib_excludes",
+                "malloc_use_scudo_whole_static_lib_excludes",
             ],
         },
     },
@@ -1215,12 +1215,12 @@ cc_library {
 }
 
 cc_library {
-    name: "malloc_not_svelte_whole_static_lib",
+    name: "malloc_use_scudo_whole_static_lib",
     bazel_module: { bp2build_available: false },
 }
 
 cc_library {
-    name: "malloc_not_svelte_whole_static_lib_excludes",
+    name: "malloc_use_scudo_whole_static_lib_excludes",
     bazel_module: { bp2build_available: false },
 }
 
@@ -1230,7 +1230,7 @@ cc_library {
 }
 
 cc_library {
-    name: "malloc_not_svelte_static_lib_excludes",
+    name: "malloc_use_scudo_static_lib_excludes",
     bazel_module: { bp2build_available: false },
 }
 
@@ -1240,7 +1240,7 @@ cc_library {
 }
 
 cc_library {
-    name: "malloc_not_svelte_shared_lib",
+    name: "malloc_use_scudo_shared_lib",
     bazel_module: { bp2build_available: false },
 }
 `,
@@ -1249,14 +1249,14 @@ cc_library {
         "//build/bazel/platforms/arch:arm": [],
         "//conditions:default": [":arm_static_lib_excludes_bp2build_cc_library_static"],
     }) + select({
-        "//build/bazel/product_variables:malloc_not_svelte": [],
-        "//conditions:default": [":malloc_not_svelte_static_lib_excludes_bp2build_cc_library_static"],
+        "//build/bazel/product_variables:malloc_use_scudo": [],
+        "//conditions:default": [":malloc_use_scudo_static_lib_excludes_bp2build_cc_library_static"],
     })`,
 			"implementation_dynamic_deps": `select({
         "//build/bazel/platforms/arch:arm": [],
         "//conditions:default": [":arm_shared_lib_excludes"],
     }) + select({
-        "//build/bazel/product_variables:malloc_not_svelte": [":malloc_not_svelte_shared_lib"],
+        "//build/bazel/product_variables:malloc_use_scudo": [":malloc_use_scudo_shared_lib"],
         "//conditions:default": [],
     })`,
 			"srcs_c": `["common.c"]`,
@@ -1264,8 +1264,8 @@ cc_library {
         "//build/bazel/platforms/arch:arm": [],
         "//conditions:default": [":arm_whole_static_lib_excludes_bp2build_cc_library_static"],
     }) + select({
-        "//build/bazel/product_variables:malloc_not_svelte": [":malloc_not_svelte_whole_static_lib_bp2build_cc_library_static"],
-        "//conditions:default": [":malloc_not_svelte_whole_static_lib_excludes_bp2build_cc_library_static"],
+        "//build/bazel/product_variables:malloc_use_scudo": [":malloc_use_scudo_whole_static_lib_bp2build_cc_library_static"],
+        "//conditions:default": [":malloc_use_scudo_whole_static_lib_excludes_bp2build_cc_library_static"],
     })`,
 		}),
 	},


### PR DESCRIPTION
Also, clean up broken DisableScudo/PRODUCT_DISABLE_SCUDO.

After these changes, malloc_not_svelte is only used to override cflags in external/jemalloc_new. Change accordingly.

Detailed reason for switching to jemalloc by default is written in the bionic commit.

Change-Id: Id5afcf064a5db6011676dc7141c71fd5bb0007cb